### PR TITLE
Run EXPLAIN less

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -215,7 +215,10 @@ func parseQueries(srcPath string, inferrer *pginfer.Inferrer) (codegen.QueryFile
 			srcQueries = append(srcQueries, query)
 
 			if query.ResultKind == ast.ResultKindSetup {
-				inferrer.RunSetup(query.PreparedSQL)
+				_, err := inferrer.RunSetup(query.PreparedSQL)
+				if err != nil {
+					return codegen.QueryFile{}, fmt.Errorf("could not run setup for %s: %w", query.Name, err)
+				}
 			}
 		default:
 			return codegen.QueryFile{}, fmt.Errorf("unhandled query ast type: %T", query)

--- a/internal/codegen/golang/templated_file.go
+++ b/internal/codegen/golang/templated_file.go
@@ -345,7 +345,7 @@ func (tq TemplatedQuery) EmitRowToFunc() (string, error) {
 // type is []FindAuthorsRow.
 func (tq TemplatedQuery) EmitSingularResultType() string {
 	if tq.ResultKind == ast.ResultKindString {
-		// This indicates a bug. This should have been caught this earlier.
+		// This indicates a bug. This should have been caught earlier.
 		panic(fmt.Errorf("unhandled EmitSingularResultType for %s query", tq.ResultKind))
 	}
 

--- a/internal/codegen/golang/templater.go
+++ b/internal/codegen/golang/templater.go
@@ -175,7 +175,7 @@ func (tm Templater) templateFile(file codegen.QueryFile, isLeader bool) (Templat
 
 		nonVoidCols := removeVoidColumns(outputs)
 		resultKind := query.ResultKind
-		if len(nonVoidCols) == 0 {
+		if len(nonVoidCols) == 0 && resultKind != ast.ResultKindString {
 			resultKind = ast.ResultKindExec
 		}
 


### PR DESCRIPTION
Not all statements can be `EXPLAIN`'d so the default of `EXPLAIN`ing everything was harming the ability for all queries to work in pggen.