### PR TITLE
Fixes for registerTypes

### DIFF
--- a/example/author/query.sql.go
+++ b/example/author/query.sql.go
@@ -107,7 +107,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -209,8 +209,6 @@ func (q *QueuedFindAuthorByID) runOnResult(result FindAuthorByIDRow) error {
 }
 
 // QueueFindAuthorByID implements Querier.QueueFindAuthorByID.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindAuthorByID(batch Batcher, authorID int32) *QueuedFindAuthorByID {
 	queued := &QueuedFindAuthorByID{}
 
@@ -281,8 +279,6 @@ func (q *QueuedFindAuthors) runOnResult(result []FindAuthorsRow) error {
 }
 
 // QueueFindAuthors implements Querier.QueueFindAuthors.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindAuthors(batch Batcher, firstName string) *QueuedFindAuthors {
 	queued := &QueuedFindAuthors{}
 
@@ -351,8 +347,6 @@ func (q *QueuedFindAuthorNames) runOnResult(result []FindAuthorNamesRow) error {
 }
 
 // QueueFindAuthorNames implements Querier.QueueFindAuthorNames.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindAuthorNames(batch Batcher, authorID int32) *QueuedFindAuthorNames {
 	queued := &QueuedFindAuthorNames{}
 
@@ -416,8 +410,6 @@ func (q *QueuedFindFirstNames) runOnResult(result []*string) error {
 }
 
 // QueueFindFirstNames implements Querier.QueueFindFirstNames.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindFirstNames(batch Batcher, authorID int32) *QueuedFindFirstNames {
 	queued := &QueuedFindFirstNames{}
 
@@ -480,8 +472,6 @@ func (q *QueuedDeleteAuthors) runOnResult(result pgconn.CommandTag) error {
 }
 
 // QueueDeleteAuthors implements Querier.QueueDeleteAuthors.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueDeleteAuthors(batch Batcher) *QueuedDeleteAuthors {
 	queued := &QueuedDeleteAuthors{}
 
@@ -540,8 +530,6 @@ func (q *QueuedDeleteAuthorsByFirstName) runOnResult(result pgconn.CommandTag) e
 }
 
 // QueueDeleteAuthorsByFirstName implements Querier.QueueDeleteAuthorsByFirstName.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueDeleteAuthorsByFirstName(batch Batcher, firstName string) *QueuedDeleteAuthorsByFirstName {
 	queued := &QueuedDeleteAuthorsByFirstName{}
 
@@ -610,8 +598,6 @@ func (q *QueuedDeleteAuthorsByFullName) runOnResult(result pgconn.CommandTag) er
 }
 
 // QueueDeleteAuthorsByFullName implements Querier.QueueDeleteAuthorsByFullName.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueDeleteAuthorsByFullName(batch Batcher, params DeleteAuthorsByFullNameParams) *QueuedDeleteAuthorsByFullName {
 	queued := &QueuedDeleteAuthorsByFullName{}
 
@@ -673,8 +659,6 @@ func (q *QueuedInsertAuthor) runOnResult(result int32) error {
 }
 
 // QueueInsertAuthor implements Querier.QueueInsertAuthor.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueInsertAuthor(batch Batcher, firstName string, lastName string) *QueuedInsertAuthor {
 	queued := &QueuedInsertAuthor{}
 
@@ -753,8 +737,6 @@ func (q *QueuedInsertAuthorSuffix) runOnResult(result InsertAuthorSuffixRow) err
 }
 
 // QueueInsertAuthorSuffix implements Querier.QueueInsertAuthorSuffix.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueInsertAuthorSuffix(batch Batcher, params InsertAuthorSuffixParams) *QueuedInsertAuthorSuffix {
 	queued := &QueuedInsertAuthorSuffix{}
 
@@ -818,8 +800,6 @@ func (q *QueuedStringAggFirstName) runOnResult(result *string) error {
 }
 
 // QueueStringAggFirstName implements Querier.QueueStringAggFirstName.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueStringAggFirstName(batch Batcher, authorID int32) *QueuedStringAggFirstName {
 	queued := &QueuedStringAggFirstName{}
 
@@ -883,8 +863,6 @@ func (q *QueuedArrayAggFirstName) runOnResult(result []string) error {
 }
 
 // QueueArrayAggFirstName implements Querier.QueueArrayAggFirstName.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueArrayAggFirstName(batch Batcher, authorID int32) *QueuedArrayAggFirstName {
 	queued := &QueuedArrayAggFirstName{}
 

--- a/example/author/query.sql.go
+++ b/example/author/query.sql.go
@@ -5,7 +5,6 @@ package author
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -95,7 +94,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -119,25 +118,38 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 	}, nil
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}

--- a/example/complex_params/query.sql.go
+++ b/example/complex_params/query.sql.go
@@ -5,7 +5,6 @@ package complex_params
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -51,7 +50,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -94,25 +93,38 @@ type ProductImageType struct {
 	Dimensions Dimensions `json:"dimensions"`
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}
@@ -128,6 +140,7 @@ var _ = addTypeToRegister("public.product_image_set_type")
 
 var _ = addTypeToRegister("public.product_image_type")
 
+var _ = addTypeToRegister("public.product_image_type")
 var _ = addTypeToRegister("public._product_image_type")
 
 const paramArrayIntSQL = `SELECT $1::bigint[];`

--- a/example/complex_params/query.sql.go
+++ b/example/complex_params/query.sql.go
@@ -63,7 +63,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -186,8 +186,6 @@ func (q *QueuedParamArrayInt) runOnResult(result []int) error {
 }
 
 // QueueParamArrayInt implements Querier.QueueParamArrayInt.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueParamArrayInt(batch Batcher, ints []int) *QueuedParamArrayInt {
 	queued := &QueuedParamArrayInt{}
 
@@ -251,8 +249,6 @@ func (q *QueuedParamNested1) runOnResult(result Dimensions) error {
 }
 
 // QueueParamNested1 implements Querier.QueueParamNested1.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueParamNested1(batch Batcher, dimensions Dimensions) *QueuedParamNested1 {
 	queued := &QueuedParamNested1{}
 
@@ -316,8 +312,6 @@ func (q *QueuedParamNested2) runOnResult(result ProductImageType) error {
 }
 
 // QueueParamNested2 implements Querier.QueueParamNested2.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueParamNested2(batch Batcher, image ProductImageType) *QueuedParamNested2 {
 	queued := &QueuedParamNested2{}
 
@@ -381,8 +375,6 @@ func (q *QueuedParamNested2Array) runOnResult(result []ProductImageType) error {
 }
 
 // QueueParamNested2Array implements Querier.QueueParamNested2Array.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueParamNested2Array(batch Batcher, images []ProductImageType) *QueuedParamNested2Array {
 	queued := &QueuedParamNested2Array{}
 
@@ -446,8 +438,6 @@ func (q *QueuedParamNested3) runOnResult(result ProductImageSetType) error {
 }
 
 // QueueParamNested3 implements Querier.QueueParamNested3.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueParamNested3(batch Batcher, imageSet ProductImageSetType) *QueuedParamNested3 {
 	queued := &QueuedParamNested3{}
 

--- a/example/composite/query.sql.go
+++ b/example/composite/query.sql.go
@@ -63,7 +63,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -207,8 +207,6 @@ func (q *QueuedSearchScreenshots) runOnResult(result []SearchScreenshotsRow) err
 }
 
 // QueueSearchScreenshots implements Querier.QueueSearchScreenshots.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueSearchScreenshots(batch Batcher, params SearchScreenshotsParams) *QueuedSearchScreenshots {
 	queued := &QueuedSearchScreenshots{}
 
@@ -285,8 +283,6 @@ func (q *QueuedSearchScreenshotsOneCol) runOnResult(result [][]Blocks) error {
 }
 
 // QueueSearchScreenshotsOneCol implements Querier.QueueSearchScreenshotsOneCol.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueSearchScreenshotsOneCol(batch Batcher, params SearchScreenshotsOneColParams) *QueuedSearchScreenshotsOneCol {
 	queued := &QueuedSearchScreenshotsOneCol{}
 
@@ -363,8 +359,6 @@ func (q *QueuedInsertScreenshotBlocks) runOnResult(result InsertScreenshotBlocks
 }
 
 // QueueInsertScreenshotBlocks implements Querier.QueueInsertScreenshotBlocks.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueInsertScreenshotBlocks(batch Batcher, screenshotID int, body string) *QueuedInsertScreenshotBlocks {
 	queued := &QueuedInsertScreenshotBlocks{}
 
@@ -428,8 +422,6 @@ func (q *QueuedArraysInput) runOnResult(result Arrays) error {
 }
 
 // QueueArraysInput implements Querier.QueueArraysInput.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueArraysInput(batch Batcher, arrays Arrays) *QueuedArraysInput {
 	queued := &QueuedArraysInput{}
 
@@ -493,8 +485,6 @@ func (q *QueuedUserEmails) runOnResult(result UserEmail) error {
 }
 
 // QueueUserEmails implements Querier.QueueUserEmails.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueUserEmails(batch Batcher) *QueuedUserEmails {
 	queued := &QueuedUserEmails{}
 

--- a/example/composite/query.sql.go
+++ b/example/composite/query.sql.go
@@ -5,7 +5,6 @@ package composite
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -51,7 +50,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -96,25 +95,38 @@ type UserEmail struct {
 	Email pgtype.Text `json:"email"`
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}
@@ -130,6 +142,7 @@ var _ = addTypeToRegister("public.blocks")
 
 var _ = addTypeToRegister("public.user_email")
 
+var _ = addTypeToRegister("public.blocks")
 var _ = addTypeToRegister("public._blocks")
 
 const searchScreenshotsSQL = `SELECT

--- a/example/custom_types/query.sql.go
+++ b/example/custom_types/query.sql.go
@@ -56,7 +56,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -156,8 +156,6 @@ func (q *QueuedCustomTypes) runOnResult(result CustomTypesRow) error {
 }
 
 // QueueCustomTypes implements Querier.QueueCustomTypes.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueCustomTypes(batch Batcher) *QueuedCustomTypes {
 	queued := &QueuedCustomTypes{}
 
@@ -221,8 +219,6 @@ func (q *QueuedCustomMyInt) runOnResult(result int) error {
 }
 
 // QueueCustomMyInt implements Querier.QueueCustomMyInt.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueCustomMyInt(batch Batcher) *QueuedCustomMyInt {
 	queued := &QueuedCustomMyInt{}
 
@@ -286,8 +282,6 @@ func (q *QueuedIntArray) runOnResult(result [][]int32) error {
 }
 
 // QueueIntArray implements Querier.QueueIntArray.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueIntArray(batch Batcher) *QueuedIntArray {
 	queued := &QueuedIntArray{}
 

--- a/example/custom_types/query.sql.go
+++ b/example/custom_types/query.sql.go
@@ -5,7 +5,6 @@ package custom_types
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -44,7 +43,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -68,25 +67,38 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 	}, nil
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}

--- a/example/device/query.sql.go
+++ b/example/device/query.sql.go
@@ -72,7 +72,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -200,8 +200,6 @@ func (q *QueuedFindDevicesByUser) runOnResult(result []FindDevicesByUserRow) err
 }
 
 // QueueFindDevicesByUser implements Querier.QueueFindDevicesByUser.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindDevicesByUser(batch Batcher, id int) *QueuedFindDevicesByUser {
 	queued := &QueuedFindDevicesByUser{}
 
@@ -276,8 +274,6 @@ func (q *QueuedCompositeUser) runOnResult(result []CompositeUserRow) error {
 }
 
 // QueueCompositeUser implements Querier.QueueCompositeUser.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueCompositeUser(batch Batcher) *QueuedCompositeUser {
 	queued := &QueuedCompositeUser{}
 
@@ -341,8 +337,6 @@ func (q *QueuedCompositeUserOne) runOnResult(result User) error {
 }
 
 // QueueCompositeUserOne implements Querier.QueueCompositeUserOne.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueCompositeUserOne(batch Batcher) *QueuedCompositeUserOne {
 	queued := &QueuedCompositeUserOne{}
 
@@ -411,8 +405,6 @@ func (q *QueuedCompositeUserOneTwoCols) runOnResult(result CompositeUserOneTwoCo
 }
 
 // QueueCompositeUserOneTwoCols implements Querier.QueueCompositeUserOneTwoCols.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueCompositeUserOneTwoCols(batch Batcher) *QueuedCompositeUserOneTwoCols {
 	queued := &QueuedCompositeUserOneTwoCols{}
 
@@ -476,8 +468,6 @@ func (q *QueuedCompositeUserMany) runOnResult(result []User) error {
 }
 
 // QueueCompositeUserMany implements Querier.QueueCompositeUserMany.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueCompositeUserMany(batch Batcher) *QueuedCompositeUserMany {
 	queued := &QueuedCompositeUserMany{}
 
@@ -541,8 +531,6 @@ func (q *QueuedInsertUser) runOnResult(result pgconn.CommandTag) error {
 }
 
 // QueueInsertUser implements Querier.QueueInsertUser.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueInsertUser(batch Batcher, userID int, name string) *QueuedInsertUser {
 	queued := &QueuedInsertUser{}
 
@@ -602,8 +590,6 @@ func (q *QueuedInsertDevice) runOnResult(result pgconn.CommandTag) error {
 }
 
 // QueueInsertDevice implements Querier.QueueInsertDevice.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueInsertDevice(batch Batcher, mac net.HardwareAddr, owner int) *QueuedInsertDevice {
 	queued := &QueuedInsertDevice{}
 

--- a/example/device/query.sql.go
+++ b/example/device/query.sql.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -60,7 +59,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -104,25 +103,38 @@ const (
 
 func (d DeviceType) String() string { return string(d) }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}

--- a/example/domain/query.sql.go
+++ b/example/domain/query.sql.go
@@ -5,7 +5,6 @@ package domain
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -35,7 +34,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -59,25 +58,38 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 	}, nil
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}

--- a/example/domain/query.sql.go
+++ b/example/domain/query.sql.go
@@ -47,7 +47,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -142,8 +142,6 @@ func (q *QueuedDomainOne) runOnResult(result string) error {
 }
 
 // QueueDomainOne implements Querier.QueueDomainOne.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueDomainOne(batch Batcher) *QueuedDomainOne {
 	queued := &QueuedDomainOne{}
 

--- a/example/enums/query.sql.go
+++ b/example/enums/query.sql.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -64,7 +63,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -108,25 +107,38 @@ const (
 
 func (d DeviceType) String() string { return string(d) }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}
@@ -138,6 +150,7 @@ func addTypeToRegister(typ string) struct{} {
 
 var _ = addTypeToRegister("public.device")
 
+var _ = addTypeToRegister("public.device_type")
 var _ = addTypeToRegister("public._device_type")
 
 const findAllDevicesSQL = `SELECT mac, type

--- a/example/enums/query.sql.go
+++ b/example/enums/query.sql.go
@@ -76,7 +76,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -202,8 +202,6 @@ func (q *QueuedFindAllDevices) runOnResult(result []FindAllDevicesRow) error {
 }
 
 // QueueFindAllDevices implements Querier.QueueFindAllDevices.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindAllDevices(batch Batcher) *QueuedFindAllDevices {
 	queued := &QueuedFindAllDevices{}
 
@@ -267,8 +265,6 @@ func (q *QueuedInsertDevice) runOnResult(result pgconn.CommandTag) error {
 }
 
 // QueueInsertDevice implements Querier.QueueInsertDevice.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueInsertDevice(batch Batcher, mac net.HardwareAddr, typePg DeviceType) *QueuedInsertDevice {
 	queued := &QueuedInsertDevice{}
 
@@ -328,8 +324,6 @@ func (q *QueuedFindOneDeviceArray) runOnResult(result []DeviceType) error {
 }
 
 // QueueFindOneDeviceArray implements Querier.QueueFindOneDeviceArray.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindOneDeviceArray(batch Batcher) *QueuedFindOneDeviceArray {
 	queued := &QueuedFindOneDeviceArray{}
 
@@ -395,8 +389,6 @@ func (q *QueuedFindManyDeviceArray) runOnResult(result [][]DeviceType) error {
 }
 
 // QueueFindManyDeviceArray implements Querier.QueueFindManyDeviceArray.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindManyDeviceArray(batch Batcher) *QueuedFindManyDeviceArray {
 	queued := &QueuedFindManyDeviceArray{}
 
@@ -467,8 +459,6 @@ func (q *QueuedFindManyDeviceArrayWithNum) runOnResult(result []FindManyDeviceAr
 }
 
 // QueueFindManyDeviceArrayWithNum implements Querier.QueueFindManyDeviceArrayWithNum.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindManyDeviceArrayWithNum(batch Batcher) *QueuedFindManyDeviceArrayWithNum {
 	queued := &QueuedFindManyDeviceArrayWithNum{}
 
@@ -532,8 +522,6 @@ func (q *QueuedEnumInsideComposite) runOnResult(result Device) error {
 }
 
 // QueueEnumInsideComposite implements Querier.QueueEnumInsideComposite.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueEnumInsideComposite(batch Batcher) *QueuedEnumInsideComposite {
 	queued := &QueuedEnumInsideComposite{}
 

--- a/example/erp/order/customer.sql.go
+++ b/example/erp/order/customer.sql.go
@@ -5,7 +5,6 @@ package order
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
@@ -61,7 +60,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -85,25 +84,38 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 	}, nil
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}

--- a/example/erp/order/customer.sql.go
+++ b/example/erp/order/customer.sql.go
@@ -73,7 +73,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -176,8 +176,6 @@ func (q *QueuedCreateTenant) runOnResult(result CreateTenantRow) error {
 }
 
 // QueueCreateTenant implements Querier.QueueCreateTenant.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueCreateTenant(batch Batcher, key string, name string) *QueuedCreateTenant {
 	queued := &QueuedCreateTenant{}
 
@@ -250,8 +248,6 @@ func (q *QueuedFindOrdersByCustomer) runOnResult(result []FindOrdersByCustomerRo
 }
 
 // QueueFindOrdersByCustomer implements Querier.QueueFindOrdersByCustomer.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindOrdersByCustomer(batch Batcher, customerID int32) *QueuedFindOrdersByCustomer {
 	queued := &QueuedFindOrdersByCustomer{}
 
@@ -325,8 +321,6 @@ func (q *QueuedFindProductsInOrder) runOnResult(result []FindProductsInOrderRow)
 }
 
 // QueueFindProductsInOrder implements Querier.QueueFindProductsInOrder.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindProductsInOrder(batch Batcher, orderID int32) *QueuedFindProductsInOrder {
 	queued := &QueuedFindProductsInOrder{}
 
@@ -405,8 +399,6 @@ func (q *QueuedInsertCustomer) runOnResult(result InsertCustomerRow) error {
 }
 
 // QueueInsertCustomer implements Querier.QueueInsertCustomer.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueInsertCustomer(batch Batcher, params InsertCustomerParams) *QueuedInsertCustomer {
 	queued := &QueuedInsertCustomer{}
 
@@ -485,8 +477,6 @@ func (q *QueuedInsertOrder) runOnResult(result InsertOrderRow) error {
 }
 
 // QueueInsertOrder implements Querier.QueueInsertOrder.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueInsertOrder(batch Batcher, params InsertOrderParams) *QueuedInsertOrder {
 	queued := &QueuedInsertOrder{}
 

--- a/example/erp/order/price.sql.go
+++ b/example/erp/order/price.sql.go
@@ -61,8 +61,6 @@ func (q *QueuedFindOrdersByPrice) runOnResult(result []FindOrdersByPriceRow) err
 }
 
 // QueueFindOrdersByPrice implements Querier.QueueFindOrdersByPrice.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindOrdersByPrice(batch Batcher, minTotal decimal.Decimal) *QueuedFindOrdersByPrice {
 	queued := &QueuedFindOrdersByPrice{}
 
@@ -133,8 +131,6 @@ func (q *QueuedFindOrdersMRR) runOnResult(result []FindOrdersMRRRow) error {
 }
 
 // QueueFindOrdersMRR implements Querier.QueueFindOrdersMRR.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindOrdersMRR(batch Batcher) *QueuedFindOrdersMRR {
 	queued := &QueuedFindOrdersMRR{}
 

--- a/example/function/query.sql.go
+++ b/example/function/query.sql.go
@@ -5,7 +5,6 @@ package function
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -35,7 +34,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -71,25 +70,38 @@ type ListStats struct {
 	Val2 []*int32 `json:"val2"`
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}
@@ -103,6 +115,7 @@ var _ = addTypeToRegister("public.list_item")
 
 var _ = addTypeToRegister("public.list_stats")
 
+var _ = addTypeToRegister("public.list_item")
 var _ = addTypeToRegister("public._list_item")
 
 const outParamsSQL = `SELECT * FROM out_params();`

--- a/example/function/query.sql.go
+++ b/example/function/query.sql.go
@@ -47,7 +47,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -166,8 +166,6 @@ func (q *QueuedOutParams) runOnResult(result []OutParamsRow) error {
 }
 
 // QueueOutParams implements Querier.QueueOutParams.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueOutParams(batch Batcher) *QueuedOutParams {
 	queued := &QueuedOutParams{}
 

--- a/example/go_pointer_types/query.sql.go
+++ b/example/go_pointer_types/query.sql.go
@@ -5,7 +5,6 @@ package go_pointer_types
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -55,7 +54,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -79,25 +78,38 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 	}, nil
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}

--- a/example/go_pointer_types/query.sql.go
+++ b/example/go_pointer_types/query.sql.go
@@ -67,7 +67,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -164,8 +164,6 @@ func (q *QueuedGenSeries1) runOnResult(result *int) error {
 }
 
 // QueueGenSeries1 implements Querier.QueueGenSeries1.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueGenSeries1(batch Batcher) *QueuedGenSeries1 {
 	queued := &QueuedGenSeries1{}
 
@@ -230,8 +228,6 @@ func (q *QueuedGenSeries) runOnResult(result []*int) error {
 }
 
 // QueueGenSeries implements Querier.QueueGenSeries.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueGenSeries(batch Batcher) *QueuedGenSeries {
 	queued := &QueuedGenSeries{}
 
@@ -296,8 +292,6 @@ func (q *QueuedGenSeriesArr1) runOnResult(result []int) error {
 }
 
 // QueueGenSeriesArr1 implements Querier.QueueGenSeriesArr1.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueGenSeriesArr1(batch Batcher) *QueuedGenSeriesArr1 {
 	queued := &QueuedGenSeriesArr1{}
 
@@ -362,8 +356,6 @@ func (q *QueuedGenSeriesArr) runOnResult(result [][]int) error {
 }
 
 // QueueGenSeriesArr implements Querier.QueueGenSeriesArr.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueGenSeriesArr(batch Batcher) *QueuedGenSeriesArr {
 	queued := &QueuedGenSeriesArr{}
 
@@ -429,8 +421,6 @@ func (q *QueuedGenSeriesStr1) runOnResult(result *string) error {
 }
 
 // QueueGenSeriesStr1 implements Querier.QueueGenSeriesStr1.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueGenSeriesStr1(batch Batcher) *QueuedGenSeriesStr1 {
 	queued := &QueuedGenSeriesStr1{}
 
@@ -495,8 +485,6 @@ func (q *QueuedGenSeriesStr) runOnResult(result []*string) error {
 }
 
 // QueueGenSeriesStr implements Querier.QueueGenSeriesStr.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueGenSeriesStr(batch Batcher) *QueuedGenSeriesStr {
 	queued := &QueuedGenSeriesStr{}
 

--- a/example/inline_param_count/inline0/query.sql.go
+++ b/example/inline_param_count/inline0/query.sql.go
@@ -5,7 +5,6 @@ package inline0
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -55,7 +54,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -79,25 +78,38 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 	}, nil
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}

--- a/example/inline_param_count/inline0/query.sql.go
+++ b/example/inline_param_count/inline0/query.sql.go
@@ -67,7 +67,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -162,8 +162,6 @@ func (q *QueuedCountAuthors) runOnResult(result *int) error {
 }
 
 // QueueCountAuthors implements Querier.QueueCountAuthors.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueCountAuthors(batch Batcher) *QueuedCountAuthors {
 	queued := &QueuedCountAuthors{}
 
@@ -238,8 +236,6 @@ func (q *QueuedFindAuthorByID) runOnResult(result FindAuthorByIDRow) error {
 }
 
 // QueueFindAuthorByID implements Querier.QueueFindAuthorByID.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindAuthorByID(batch Batcher, params FindAuthorByIDParams) *QueuedFindAuthorByID {
 	queued := &QueuedFindAuthorByID{}
 
@@ -310,8 +306,6 @@ func (q *QueuedInsertAuthor) runOnResult(result int32) error {
 }
 
 // QueueInsertAuthor implements Querier.QueueInsertAuthor.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueInsertAuthor(batch Batcher, params InsertAuthorParams) *QueuedInsertAuthor {
 	queued := &QueuedInsertAuthor{}
 
@@ -384,8 +378,6 @@ func (q *QueuedDeleteAuthorsByFullName) runOnResult(result pgconn.CommandTag) er
 }
 
 // QueueDeleteAuthorsByFullName implements Querier.QueueDeleteAuthorsByFullName.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueDeleteAuthorsByFullName(batch Batcher, params DeleteAuthorsByFullNameParams) *QueuedDeleteAuthorsByFullName {
 	queued := &QueuedDeleteAuthorsByFullName{}
 

--- a/example/inline_param_count/inline1/query.sql.go
+++ b/example/inline_param_count/inline1/query.sql.go
@@ -67,7 +67,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -162,8 +162,6 @@ func (q *QueuedCountAuthors) runOnResult(result *int) error {
 }
 
 // QueueCountAuthors implements Querier.QueueCountAuthors.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueCountAuthors(batch Batcher) *QueuedCountAuthors {
 	queued := &QueuedCountAuthors{}
 
@@ -234,8 +232,6 @@ func (q *QueuedFindAuthorByID) runOnResult(result FindAuthorByIDRow) error {
 }
 
 // QueueFindAuthorByID implements Querier.QueueFindAuthorByID.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindAuthorByID(batch Batcher, authorID int32) *QueuedFindAuthorByID {
 	queued := &QueuedFindAuthorByID{}
 
@@ -306,8 +302,6 @@ func (q *QueuedInsertAuthor) runOnResult(result int32) error {
 }
 
 // QueueInsertAuthor implements Querier.QueueInsertAuthor.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueInsertAuthor(batch Batcher, params InsertAuthorParams) *QueuedInsertAuthor {
 	queued := &QueuedInsertAuthor{}
 
@@ -380,8 +374,6 @@ func (q *QueuedDeleteAuthorsByFullName) runOnResult(result pgconn.CommandTag) er
 }
 
 // QueueDeleteAuthorsByFullName implements Querier.QueueDeleteAuthorsByFullName.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueDeleteAuthorsByFullName(batch Batcher, params DeleteAuthorsByFullNameParams) *QueuedDeleteAuthorsByFullName {
 	queued := &QueuedDeleteAuthorsByFullName{}
 

--- a/example/inline_param_count/inline1/query.sql.go
+++ b/example/inline_param_count/inline1/query.sql.go
@@ -5,7 +5,6 @@ package inline1
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -55,7 +54,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -79,25 +78,38 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 	}, nil
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}

--- a/example/inline_param_count/inline2/query.sql.go
+++ b/example/inline_param_count/inline2/query.sql.go
@@ -67,7 +67,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -162,8 +162,6 @@ func (q *QueuedCountAuthors) runOnResult(result *int) error {
 }
 
 // QueueCountAuthors implements Querier.QueueCountAuthors.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueCountAuthors(batch Batcher) *QueuedCountAuthors {
 	queued := &QueuedCountAuthors{}
 
@@ -234,8 +232,6 @@ func (q *QueuedFindAuthorByID) runOnResult(result FindAuthorByIDRow) error {
 }
 
 // QueueFindAuthorByID implements Querier.QueueFindAuthorByID.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindAuthorByID(batch Batcher, authorID int32) *QueuedFindAuthorByID {
 	queued := &QueuedFindAuthorByID{}
 
@@ -301,8 +297,6 @@ func (q *QueuedInsertAuthor) runOnResult(result int32) error {
 }
 
 // QueueInsertAuthor implements Querier.QueueInsertAuthor.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueInsertAuthor(batch Batcher, firstName string, lastName string) *QueuedInsertAuthor {
 	queued := &QueuedInsertAuthor{}
 
@@ -375,8 +369,6 @@ func (q *QueuedDeleteAuthorsByFullName) runOnResult(result pgconn.CommandTag) er
 }
 
 // QueueDeleteAuthorsByFullName implements Querier.QueueDeleteAuthorsByFullName.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueDeleteAuthorsByFullName(batch Batcher, params DeleteAuthorsByFullNameParams) *QueuedDeleteAuthorsByFullName {
 	queued := &QueuedDeleteAuthorsByFullName{}
 

--- a/example/inline_param_count/inline2/query.sql.go
+++ b/example/inline_param_count/inline2/query.sql.go
@@ -5,7 +5,6 @@ package inline2
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -55,7 +54,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -79,25 +78,38 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 	}, nil
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}

--- a/example/inline_param_count/inline3/query.sql.go
+++ b/example/inline_param_count/inline3/query.sql.go
@@ -5,7 +5,6 @@ package inline3
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -55,7 +54,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -79,25 +78,38 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 	}, nil
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}

--- a/example/inline_param_count/inline3/query.sql.go
+++ b/example/inline_param_count/inline3/query.sql.go
@@ -67,7 +67,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -162,8 +162,6 @@ func (q *QueuedCountAuthors) runOnResult(result *int) error {
 }
 
 // QueueCountAuthors implements Querier.QueueCountAuthors.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueCountAuthors(batch Batcher) *QueuedCountAuthors {
 	queued := &QueuedCountAuthors{}
 
@@ -234,8 +232,6 @@ func (q *QueuedFindAuthorByID) runOnResult(result FindAuthorByIDRow) error {
 }
 
 // QueueFindAuthorByID implements Querier.QueueFindAuthorByID.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindAuthorByID(batch Batcher, authorID int32) *QueuedFindAuthorByID {
 	queued := &QueuedFindAuthorByID{}
 
@@ -301,8 +297,6 @@ func (q *QueuedInsertAuthor) runOnResult(result int32) error {
 }
 
 // QueueInsertAuthor implements Querier.QueueInsertAuthor.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueInsertAuthor(batch Batcher, firstName string, lastName string) *QueuedInsertAuthor {
 	queued := &QueuedInsertAuthor{}
 
@@ -369,8 +363,6 @@ func (q *QueuedDeleteAuthorsByFullName) runOnResult(result pgconn.CommandTag) er
 }
 
 // QueueDeleteAuthorsByFullName implements Querier.QueueDeleteAuthorsByFullName.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueDeleteAuthorsByFullName(batch Batcher, firstName string, lastName string, suffix string) *QueuedDeleteAuthorsByFullName {
 	queued := &QueuedDeleteAuthorsByFullName{}
 

--- a/example/ltree/query.sql.go
+++ b/example/ltree/query.sql.go
@@ -59,7 +59,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -156,8 +156,6 @@ func (q *QueuedFindTopScienceChildren) runOnResult(result []pgtype.Text) error {
 }
 
 // QueueFindTopScienceChildren implements Querier.QueueFindTopScienceChildren.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindTopScienceChildren(batch Batcher) *QueuedFindTopScienceChildren {
 	queued := &QueuedFindTopScienceChildren{}
 
@@ -223,8 +221,6 @@ func (q *QueuedFindTopScienceChildrenAgg) runOnResult(result pgtype.TextArray) e
 }
 
 // QueueFindTopScienceChildrenAgg implements Querier.QueueFindTopScienceChildrenAgg.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindTopScienceChildrenAgg(batch Batcher) *QueuedFindTopScienceChildrenAgg {
 	queued := &QueuedFindTopScienceChildrenAgg{}
 
@@ -300,8 +296,6 @@ func (q *QueuedInsertSampleData) runOnResult(result pgconn.CommandTag) error {
 }
 
 // QueueInsertSampleData implements Querier.QueueInsertSampleData.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueInsertSampleData(batch Batcher) *QueuedInsertSampleData {
 	queued := &QueuedInsertSampleData{}
 
@@ -375,8 +369,6 @@ func (q *QueuedFindLtreeInput) runOnResult(result FindLtreeInputRow) error {
 }
 
 // QueueFindLtreeInput implements Querier.QueueFindLtreeInput.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindLtreeInput(batch Batcher, inLtree pgtype.Text, inLtreeArray []string) *QueuedFindLtreeInput {
 	queued := &QueuedFindLtreeInput{}
 

--- a/example/ltree/query.sql.go
+++ b/example/ltree/query.sql.go
@@ -5,7 +5,6 @@ package ltree
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -47,7 +46,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -71,25 +70,38 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 	}, nil
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}

--- a/example/nested/query.sql.go
+++ b/example/nested/query.sql.go
@@ -5,7 +5,6 @@ package nested
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -39,7 +38,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -82,25 +81,38 @@ type ProductImageType struct {
 	Dimensions Dimensions `json:"dimensions"`
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}
@@ -116,6 +128,7 @@ var _ = addTypeToRegister("public.product_image_set_type")
 
 var _ = addTypeToRegister("public.product_image_type")
 
+var _ = addTypeToRegister("public.product_image_type")
 var _ = addTypeToRegister("public._product_image_type")
 
 const arrayNested2SQL = `SELECT

--- a/example/nested/query.sql.go
+++ b/example/nested/query.sql.go
@@ -51,7 +51,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -178,8 +178,6 @@ func (q *QueuedArrayNested2) runOnResult(result []ProductImageType) error {
 }
 
 // QueueArrayNested2 implements Querier.QueueArrayNested2.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueArrayNested2(batch Batcher) *QueuedArrayNested2 {
 	queued := &QueuedArrayNested2{}
 
@@ -251,8 +249,6 @@ func (q *QueuedNested3) runOnResult(result []ProductImageSetType) error {
 }
 
 // QueueNested3 implements Querier.QueueNested3.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueNested3(batch Batcher) *QueuedNested3 {
 	queued := &QueuedNested3{}
 

--- a/example/pgcrypto/query.sql.go
+++ b/example/pgcrypto/query.sql.go
@@ -5,7 +5,6 @@ package pgcrypto
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -39,7 +38,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -63,25 +62,38 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 	}, nil
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}

--- a/example/pgcrypto/query.sql.go
+++ b/example/pgcrypto/query.sql.go
@@ -51,7 +51,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -146,8 +146,6 @@ func (q *QueuedCreateUser) runOnResult(result pgconn.CommandTag) error {
 }
 
 // QueueCreateUser implements Querier.QueueCreateUser.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueCreateUser(batch Batcher, email string, password string) *QueuedCreateUser {
 	queued := &QueuedCreateUser{}
 
@@ -213,8 +211,6 @@ func (q *QueuedFindUser) runOnResult(result FindUserRow) error {
 }
 
 // QueueFindUser implements Querier.QueueFindUser.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindUser(batch Batcher, email string) *QueuedFindUser {
 	queued := &QueuedFindUser{}
 

--- a/example/separate_out_dir/out/alpha_query.sql.0.go
+++ b/example/separate_out_dir/out/alpha_query.sql.0.go
@@ -5,7 +5,6 @@ package out
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -47,7 +46,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -76,25 +75,38 @@ type Alpha struct {
 	Key *string `json:"key"`
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}
@@ -106,6 +118,7 @@ func addTypeToRegister(typ string) struct{} {
 
 var _ = addTypeToRegister("public.alpha")
 
+var _ = addTypeToRegister("public.alpha")
 var _ = addTypeToRegister("public._alpha")
 
 const alphaNestedSQL = `SELECT 'alpha_nested' as output;`

--- a/example/separate_out_dir/out/alpha_query.sql.0.go
+++ b/example/separate_out_dir/out/alpha_query.sql.0.go
@@ -59,7 +59,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -164,8 +164,6 @@ func (q *QueuedAlphaNested) runOnResult(result string) error {
 }
 
 // QueueAlphaNested implements Querier.QueueAlphaNested.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueAlphaNested(batch Batcher) *QueuedAlphaNested {
 	queued := &QueuedAlphaNested{}
 
@@ -229,8 +227,6 @@ func (q *QueuedAlphaCompositeArray) runOnResult(result []Alpha) error {
 }
 
 // QueueAlphaCompositeArray implements Querier.QueueAlphaCompositeArray.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueAlphaCompositeArray(batch Batcher) *QueuedAlphaCompositeArray {
 	queued := &QueuedAlphaCompositeArray{}
 

--- a/example/separate_out_dir/out/alpha_query.sql.1.go
+++ b/example/separate_out_dir/out/alpha_query.sql.1.go
@@ -52,8 +52,6 @@ func (q *QueuedAlpha) runOnResult(result string) error {
 }
 
 // QueueAlpha implements Querier.QueueAlpha.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueAlpha(batch Batcher) *QueuedAlpha {
 	queued := &QueuedAlpha{}
 

--- a/example/separate_out_dir/out/bravo_query.sql.go
+++ b/example/separate_out_dir/out/bravo_query.sql.go
@@ -52,8 +52,6 @@ func (q *QueuedBravo) runOnResult(result string) error {
 }
 
 // QueueBravo implements Querier.QueueBravo.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueBravo(batch Batcher) *QueuedBravo {
 	queued := &QueuedBravo{}
 

--- a/example/slices/query.sql.go
+++ b/example/slices/query.sql.go
@@ -5,7 +5,6 @@ package slices
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
@@ -48,7 +47,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -72,25 +71,38 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 	}, nil
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}

--- a/example/slices/query.sql.go
+++ b/example/slices/query.sql.go
@@ -60,7 +60,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -155,8 +155,6 @@ func (q *QueuedGetBools) runOnResult(result []bool) error {
 }
 
 // QueueGetBools implements Querier.QueueGetBools.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueGetBools(batch Batcher, data []bool) *QueuedGetBools {
 	queued := &QueuedGetBools{}
 
@@ -220,8 +218,6 @@ func (q *QueuedGetOneTimestamp) runOnResult(result *time.Time) error {
 }
 
 // QueueGetOneTimestamp implements Querier.QueueGetOneTimestamp.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueGetOneTimestamp(batch Batcher, data *time.Time) *QueuedGetOneTimestamp {
 	queued := &QueuedGetOneTimestamp{}
 
@@ -286,8 +282,6 @@ func (q *QueuedGetManyTimestamptzs) runOnResult(result []*time.Time) error {
 }
 
 // QueueGetManyTimestamptzs implements Querier.QueueGetManyTimestamptzs.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueGetManyTimestamptzs(batch Batcher, data []time.Time) *QueuedGetManyTimestamptzs {
 	queued := &QueuedGetManyTimestamptzs{}
 
@@ -352,8 +346,6 @@ func (q *QueuedGetManyTimestamps) runOnResult(result []*time.Time) error {
 }
 
 // QueueGetManyTimestamps implements Querier.QueueGetManyTimestamps.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueGetManyTimestamps(batch Batcher, data []*time.Time) *QueuedGetManyTimestamps {
 	queued := &QueuedGetManyTimestamps{}
 

--- a/example/syntax/query.sql.go
+++ b/example/syntax/query.sql.go
@@ -95,7 +95,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -202,8 +202,6 @@ func (q *QueuedBacktick) runOnResult(result string) error {
 }
 
 // QueueBacktick implements Querier.QueueBacktick.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueBacktick(batch Batcher) *QueuedBacktick {
 	queued := &QueuedBacktick{}
 
@@ -267,8 +265,6 @@ func (q *QueuedBacktickQuoteBacktick) runOnResult(result string) error {
 }
 
 // QueueBacktickQuoteBacktick implements Querier.QueueBacktickQuoteBacktick.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueBacktickQuoteBacktick(batch Batcher) *QueuedBacktickQuoteBacktick {
 	queued := &QueuedBacktickQuoteBacktick{}
 
@@ -332,8 +328,6 @@ func (q *QueuedBacktickNewline) runOnResult(result string) error {
 }
 
 // QueueBacktickNewline implements Querier.QueueBacktickNewline.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueBacktickNewline(batch Batcher) *QueuedBacktickNewline {
 	queued := &QueuedBacktickNewline{}
 
@@ -397,8 +391,6 @@ func (q *QueuedBacktickDoubleQuote) runOnResult(result string) error {
 }
 
 // QueueBacktickDoubleQuote implements Querier.QueueBacktickDoubleQuote.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueBacktickDoubleQuote(batch Batcher) *QueuedBacktickDoubleQuote {
 	queued := &QueuedBacktickDoubleQuote{}
 
@@ -462,8 +454,6 @@ func (q *QueuedBacktickBackslashN) runOnResult(result string) error {
 }
 
 // QueueBacktickBackslashN implements Querier.QueueBacktickBackslashN.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueBacktickBackslashN(batch Batcher) *QueuedBacktickBackslashN {
 	queued := &QueuedBacktickBackslashN{}
 
@@ -532,8 +522,6 @@ func (q *QueuedIllegalNameSymbols) runOnResult(result IllegalNameSymbolsRow) err
 }
 
 // QueueIllegalNameSymbols implements Querier.QueueIllegalNameSymbols.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueIllegalNameSymbols(batch Batcher, helloWorld string) *QueuedIllegalNameSymbols {
 	queued := &QueuedIllegalNameSymbols{}
 
@@ -597,8 +585,6 @@ func (q *QueuedSpaceAfter) runOnResult(result string) error {
 }
 
 // QueueSpaceAfter implements Querier.QueueSpaceAfter.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueSpaceAfter(batch Batcher, space string) *QueuedSpaceAfter {
 	queued := &QueuedSpaceAfter{}
 
@@ -662,8 +648,6 @@ func (q *QueuedBadEnumName) runOnResult(result UnnamedEnum123) error {
 }
 
 // QueueBadEnumName implements Querier.QueueBadEnumName.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueBadEnumName(batch Batcher) *QueuedBadEnumName {
 	queued := &QueuedBadEnumName{}
 
@@ -727,8 +711,6 @@ func (q *QueuedGoKeyword) runOnResult(result string) error {
 }
 
 // QueueGoKeyword implements Querier.QueueGoKeyword.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueGoKeyword(batch Batcher, go_ string) *QueuedGoKeyword {
 	queued := &QueuedGoKeyword{}
 

--- a/example/syntax/query.sql.go
+++ b/example/syntax/query.sql.go
@@ -5,7 +5,6 @@ package syntax
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -83,7 +82,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -119,25 +118,38 @@ const (
 
 func (u UnnamedEnum123) String() string { return string(u) }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}

--- a/example/void/query.sql.go
+++ b/example/void/query.sql.go
@@ -63,7 +63,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -157,8 +157,6 @@ func (q *QueuedVoidOnly) runOnResult(result pgconn.CommandTag) error {
 }
 
 // QueueVoidOnly implements Querier.QueueVoidOnly.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueVoidOnly(batch Batcher) *QueuedVoidOnly {
 	queued := &QueuedVoidOnly{}
 
@@ -217,8 +215,6 @@ func (q *QueuedVoidOnlyTwoParams) runOnResult(result pgconn.CommandTag) error {
 }
 
 // QueueVoidOnlyTwoParams implements Querier.QueueVoidOnlyTwoParams.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueVoidOnlyTwoParams(batch Batcher, id int32) *QueuedVoidOnlyTwoParams {
 	queued := &QueuedVoidOnlyTwoParams{}
 
@@ -278,8 +274,6 @@ func (q *QueuedVoidTwo) runOnResult(result string) error {
 }
 
 // QueueVoidTwo implements Querier.QueueVoidTwo.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueVoidTwo(batch Batcher) *QueuedVoidTwo {
 	queued := &QueuedVoidTwo{}
 
@@ -348,8 +342,6 @@ func (q *QueuedVoidThree) runOnResult(result VoidThreeRow) error {
 }
 
 // QueueVoidThree implements Querier.QueueVoidThree.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueVoidThree(batch Batcher) *QueuedVoidThree {
 	queued := &QueuedVoidThree{}
 
@@ -413,8 +405,6 @@ func (q *QueuedVoidThree2) runOnResult(result []string) error {
 }
 
 // QueueVoidThree2 implements Querier.QueueVoidThree2.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueVoidThree2(batch Batcher) *QueuedVoidThree2 {
 	queued := &QueuedVoidThree2{}
 

--- a/example/void/query.sql.go
+++ b/example/void/query.sql.go
@@ -5,7 +5,6 @@ package void
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -51,7 +50,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -75,25 +74,38 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 	}, nil
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}

--- a/internal/codegen/golang/query.gotemplate
+++ b/internal/codegen/golang/query.gotemplate
@@ -139,6 +139,10 @@ func (q *Queued{{ $q.Name }}) runWrapError(err error) error {
 }
 
 func (q *Queued{{ $q.Name }}) runOnResult(result {{ $q.EmitResultType }}) error {
+    {{- if eq $q.ResultKind ":rows" }}
+    defer result.Close()
+    {{- end }}
+
 	if q.onResult == nil {
 		return nil
 	}

--- a/internal/codegen/golang/query.gotemplate
+++ b/internal/codegen/golang/query.gotemplate
@@ -69,7 +69,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	};
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -147,7 +147,6 @@ func (q *Queued{{ $q.Name }}) runOnResult(result {{ $q.EmitResultType }}) error 
 }
 
 // Queue{{ $q.Name }} implements Querier.Queue{{ $q.Name }}.
-//nolint:contextcheck
 func (q *DBQuerier) Queue{{ $q.Name }}(batch Batcher {{- $q.EmitParams }}) *Queued{{ $q.Name }} {
 	queued := &Queued{{ $q.Name }}{}
 

--- a/internal/codegen/golang/query.gotemplate
+++ b/internal/codegen/golang/query.gotemplate
@@ -56,7 +56,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {

--- a/internal/pg/query.sql
+++ b/internal/pg/query.sql
@@ -23,6 +23,8 @@ SELECT
   typ.oid           AS oid,
   -- typename: Data type name.
   typ.typname::text AS type_name,
+  nsp.nspname::text AS namespace_name,
+  nsp.oid           AS namespace_oid,
   enum.enum_oids    AS child_oids,
   enum.enum_orders  AS orders,
   enum.enum_labels  AS labels,
@@ -38,6 +40,7 @@ SELECT
   -- to the type's input converter to produce a constant.
   COALESCE(typ.typdefault, '')    AS default_expr
 FROM pg_type typ
+  JOIN pg_namespace nsp ON typ.typnamespace = nsp.oid
   JOIN enums enum ON typ.oid = enum.enum_type
 WHERE typ.typisdefined
   AND typ.typtype = 'e'
@@ -158,6 +161,11 @@ FROM pg_type
 WHERE oid = pggen.arg('oid');
 
 -- name: FindOIDNames :many
-SELECT oid, typname AS name, typtype AS kind
-FROM pg_type
-WHERE oid = ANY (pggen.arg('oid')::oid[]);
+SELECT
+    typ.oid,
+    nsp.nspname AS namespace_name,
+    typname     AS name,
+    typtype     AS kind
+FROM pg_type typ
+  JOIN pg_namespace nsp ON typ.typnamespace = nsp.oid
+WHERE typ.oid = ANY (pggen.arg('oid')::oid[]);

--- a/internal/pg/query.sql.go
+++ b/internal/pg/query.sql.go
@@ -5,7 +5,6 @@ package pg
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
@@ -69,7 +68,7 @@ type genericConn interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	TypeMap() *pgtype.Map
-	LoadType(ctx context.Context, typeName string) (*pgtype.Type, error)
+	LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error)
 }
 
 type Batcher interface {
@@ -93,25 +92,38 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 	}, nil
 }
 
-var registerOnce sync.Once
-var registerErr error
-
 func registerTypes(ctx context.Context, conn genericConn) error {
-	registerOnce.Do(func() {
-		typeMap := conn.TypeMap()
+	typeMap := conn.TypeMap()
 
-		pgxdecimal.Register(typeMap)
-		for _, typ := range typesToRegister {
-			dt, err := conn.LoadType(ctx, typ)
-			if err != nil {
-				registerErr = fmt.Errorf("could not register type %q: %w", typ, err)
-				return
-			}
-			typeMap.RegisterType(dt)
+	// The work pgxdecimal.Register does involves no queries so it may as well
+	// be free.
+	pgxdecimal.Register(typeMap)
+
+	// Make sure to only register the necessary types. This is really only
+	// important for the frequent path of _no_ registrations necessary which
+	// would cause an unnecessary extra roundtrip on every query.
+	needsRegistering := make([]string, 0, len(typesToRegister))
+	for _, typeName := range typesToRegister {
+		_, exists := typeMap.TypeForName(typeName)
+		if exists {
+			continue
 		}
-	})
 
-	return registerErr
+		needsRegistering = append(needsRegistering, typeName)
+	}
+
+	if len(needsRegistering) == 0 {
+		return nil
+	}
+
+	types, err := conn.LoadTypes(ctx, needsRegistering)
+	if err != nil {
+		return fmt.Errorf("could not register types: %w", err)
+	}
+
+	typeMap.RegisterTypes(types)
+
+	return nil
 }
 
 var typesToRegister = []string{}
@@ -145,6 +157,8 @@ SELECT
   typ.oid           AS oid,
   -- typename: Data type name.
   typ.typname::text AS type_name,
+  nsp.nspname::text AS namespace_name,
+  nsp.oid           AS namespace_oid,
   enum.enum_oids    AS child_oids,
   enum.enum_orders  AS orders,
   enum.enum_labels  AS labels,
@@ -160,19 +174,22 @@ SELECT
   -- to the type's input converter to produce a constant.
   COALESCE(typ.typdefault, '')    AS default_expr
 FROM pg_type typ
+  JOIN pg_namespace nsp ON typ.typnamespace = nsp.oid
   JOIN enums enum ON typ.oid = enum.enum_type
 WHERE typ.typisdefined
   AND typ.typtype = 'e'
   AND typ.oid = ANY ($1::oid[]);`
 
 type FindEnumTypesRow struct {
-	OID         uint32    `json:"oid"`
-	TypeName    string    `json:"type_name"`
-	ChildOIDs   []int     `json:"child_oids"`
-	Orders      []float32 `json:"orders"`
-	Labels      []string  `json:"labels"`
-	TypeKind    byte      `json:"type_kind"`
-	DefaultExpr string    `json:"default_expr"`
+	OID           uint32    `json:"oid"`
+	TypeName      string    `json:"type_name"`
+	NamespaceName string    `json:"namespace_name"`
+	NamespaceOID  uint32    `json:"namespace_oid"`
+	ChildOIDs     []int     `json:"child_oids"`
+	Orders        []float32 `json:"orders"`
+	Labels        []string  `json:"labels"`
+	TypeKind      byte      `json:"type_kind"`
+	DefaultExpr   string    `json:"default_expr"`
 }
 
 // FindEnumTypes implements Querier.FindEnumTypes.
@@ -678,14 +695,20 @@ func (q *DBQuerier) QueueFindOIDName(batch Batcher, oid uint32) *QueuedFindOIDNa
 	return queued
 }
 
-const findOIDNamesSQL = `SELECT oid, typname AS name, typtype AS kind
-FROM pg_type
-WHERE oid = ANY ($1::oid[]);`
+const findOIDNamesSQL = `SELECT
+    typ.oid,
+    nsp.nspname AS namespace_name,
+    typname     AS name,
+    typtype     AS kind
+FROM pg_type typ
+  JOIN pg_namespace nsp ON typ.typnamespace = nsp.oid
+WHERE typ.oid = ANY ($1::oid[]);`
 
 type FindOIDNamesRow struct {
-	OID  uint32 `json:"oid"`
-	Name string `json:"name"`
-	Kind byte   `json:"kind"`
+	OID           uint32 `json:"oid"`
+	NamespaceName string `json:"namespace_name"`
+	Name          string `json:"name"`
+	Kind          byte   `json:"kind"`
 }
 
 // FindOIDNames implements Querier.FindOIDNames.

--- a/internal/pg/query.sql.go
+++ b/internal/pg/query.sql.go
@@ -81,7 +81,7 @@ func NewQuerier(ctx context.Context, conn genericConn) (*DBQuerier, error) {
 		return err
 	}
 
-	err := registerTypes(context.Background(), conn)
+	err := registerTypes(ctx, conn)
 	if err != nil {
 		return nil, errWrap(fmt.Errorf("could not register types: %w", err))
 	}
@@ -233,8 +233,6 @@ func (q *QueuedFindEnumTypes) runOnResult(result []FindEnumTypesRow) error {
 }
 
 // QueueFindEnumTypes implements Querier.QueueFindEnumTypes.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindEnumTypes(batch Batcher, oids []uint32) *QueuedFindEnumTypes {
 	queued := &QueuedFindEnumTypes{}
 
@@ -337,8 +335,6 @@ func (q *QueuedFindArrayTypes) runOnResult(result []FindArrayTypesRow) error {
 }
 
 // QueueFindArrayTypes implements Querier.QueueFindArrayTypes.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindArrayTypes(batch Batcher, oids []uint32) *QueuedFindArrayTypes {
 	queued := &QueuedFindArrayTypes{}
 
@@ -446,8 +442,6 @@ func (q *QueuedFindCompositeTypes) runOnResult(result []FindCompositeTypesRow) e
 }
 
 // QueueFindCompositeTypes implements Querier.QueueFindCompositeTypes.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindCompositeTypes(batch Batcher, oids []uint32) *QueuedFindCompositeTypes {
 	queued := &QueuedFindCompositeTypes{}
 
@@ -537,8 +531,6 @@ func (q *QueuedFindDescendantOIDs) runOnResult(result []uint32) error {
 }
 
 // QueueFindDescendantOIDs implements Querier.QueueFindDescendantOIDs.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindDescendantOIDs(batch Batcher, oids []uint32) *QueuedFindDescendantOIDs {
 	queued := &QueuedFindDescendantOIDs{}
 
@@ -606,8 +598,6 @@ func (q *QueuedFindOIDByName) runOnResult(result uint32) error {
 }
 
 // QueueFindOIDByName implements Querier.QueueFindOIDByName.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindOIDByName(batch Batcher, name string) *QueuedFindOIDByName {
 	queued := &QueuedFindOIDByName{}
 
@@ -673,8 +663,6 @@ func (q *QueuedFindOIDName) runOnResult(result string) error {
 }
 
 // QueueFindOIDName implements Querier.QueueFindOIDName.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindOIDName(batch Batcher, oid uint32) *QueuedFindOIDName {
 	queued := &QueuedFindOIDName{}
 
@@ -752,8 +740,6 @@ func (q *QueuedFindOIDNames) runOnResult(result []FindOIDNamesRow) error {
 }
 
 // QueueFindOIDNames implements Querier.QueueFindOIDNames.
-//
-//nolint:contextcheck
 func (q *DBQuerier) QueueFindOIDNames(batch Batcher, oid []uint32) *QueuedFindOIDNames {
 	queued := &QueuedFindOIDNames{}
 

--- a/internal/pg/type_fetcher.go
+++ b/internal/pg/type_fetcher.go
@@ -115,6 +115,7 @@ func (tf *TypeFetcher) findEnumTypes(ctx context.Context, uncached map[uint32]st
 		}
 		types[i] = EnumType{
 			ID:        enum.OID,
+			Schema:    enum.NamespaceName,
 			Name:      enum.TypeName,
 			Labels:    enum.Labels,
 			Orders:    enum.Orders,
@@ -159,8 +160,8 @@ func (tf *TypeFetcher) findCompositeTypes(ctx context.Context, uncached map[uint
 		}
 		typ := CompositeType{
 			ID:          row.TableTypeOID,
-			Name:        row.TableName,
 			Schema:      row.TableNamespaceName,
+			Name:        row.TableName,
 			ColumnNames: colNames,
 			ColumnTypes: colTypes,
 		}
@@ -180,6 +181,7 @@ func (tf *TypeFetcher) findUnknownTypes(ctx context.Context, uncached map[uint32
 	for i, row := range rows {
 		types[i] = UnknownType{
 			ID:     row.OID,
+			Schema: row.NamespaceName,
 			Name:   row.Name,
 			PgKind: TypeKind(row.Kind),
 		}

--- a/internal/pg/types.go
+++ b/internal/pg/types.go
@@ -49,8 +49,10 @@ type (
 	// BaseType is a fundamental Postgres type like text and bool.
 	// https://www.postgresql.org/docs/13/catalog-pg-type.html
 	BaseType struct {
-		ID   uint32 // pg_type.oid: row identifier
-		Name string // pg_type.typname: data type name
+		// pg_type.oid: row identifier
+		ID uint32
+		// pg_type.typname: data type name
+		Name string
 	}
 
 	// VoidType is an empty type. A void type doesn't appear in output, but it's
@@ -72,6 +74,8 @@ type (
 
 	EnumType struct {
 		ID uint32 // pg_type.oid: row identifier
+		// pg_namespace.nspname: name of the schema
+		Schema string
 		// The name of the enum, like 'device_type' in:
 		//     CREATE TYPE device_type AS ENUM ('foo');
 		// From pg_type.typname.
@@ -87,9 +91,10 @@ type (
 		ChildOIDs []uint32
 	}
 
-	// DomainType is a user-create domain type.
+	// DomainType is a user-created domain type.
 	DomainType struct {
 		ID         uint32   // pg_type.oid: row identifier
+		Schema     string   // pg_namespace.nspname: name of the schema
 		Name       string   // pg_type.typname: data type name
 		IsNotNull  bool     // pg_type.typnotnull: domains only, not null constraint for domains
 		HasDefault bool     // pg_type.typdefault: domains only, if there's a default value
@@ -101,8 +106,8 @@ type (
 	// a class. https://www.postgresql.org/docs/13/catalog-pg-class.html
 	CompositeType struct {
 		ID          uint32   // pg_class.oid: row identifier
-		Name        string   // pg_class.relname: name of the composite type
 		Schema      string   // pg_namespace.nspname: name of the schema
+		Name        string   // pg_class.relname: name of the composite type
 		ColumnNames []string // pg_attribute.attname: names of the column, in order
 		ColumnTypes []Type   // pg_attribute JOIN pg_type: information about columns of the composite type
 	}
@@ -113,6 +118,7 @@ type (
 	// like --go-type my_int=int.
 	UnknownType struct {
 		ID     uint32 // pg_type.oid: row identifier
+		Schema string // pg_namespace.nspname: name of the schema
 		Name   string // pg_type.typname: data type name
 		PgKind TypeKind
 	}


### PR DESCRIPTION
I also noticed that `registerTypes` was only running once, total, which isn't correct when there are multiple connections, for example in tests. I could have moved to one `sync.Once` per `NewQuerier` but because of #9 it's running on initialization now anyways (for the `Queue`) methods.