### PR TITLE
Fix `(*gotype.PointerType).Import`

### DIFF
--- a/internal/codegen/golang/gotype/types.go
+++ b/internal/codegen/golang/gotype/types.go
@@ -89,7 +89,7 @@ func (e *ImportType) BaseName() string { return e.Type.BaseName() }
 func (o *OpaqueType) Import() string   { return "" }
 func (o *OpaqueType) BaseName() string { return o.Name }
 
-func (o *PointerType) Import() string   { return "" }
+func (o *PointerType) Import() string   { return o.Elem.Import() }
 func (o *PointerType) BaseName() string { return "*" + o.Elem.BaseName() }
 
 func (e *VoidType) Import() string   { return "" }


### PR DESCRIPTION
We hit a new codepath with our override to `"numeric": "*github.com/mypricehealth/decimal.Decimal",`. Specifically it was not properly adding an import because it's a pointer and the import from the element wasn't passed through.