### PR TITLE
Fix one off error for query in error message

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -242,7 +242,7 @@ func (p *parser) parseQuery() ast.Query {
 	var nextLeadComments ast.CommentGroup
 	for {
 		if p.tok == token.EOF || p.tok == token.Illegal {
-			p.error(p.pos, "unterminated query (no semicolon): "+string(p.src[pos:p.pos]))
+			p.error(p.pos, "unterminated query (no semicolon): "+string(p.src[queryStartPos:p.pos]))
 			return &ast.BadQuery{From: pos, To: p.pos}
 		}
 


### PR DESCRIPTION
Noticed that the first character hasn't been printed in this `pggen` error and decided to finally fix it.